### PR TITLE
Allow overriding of system name from config

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -65,6 +65,11 @@ return [
             // configuration value
             'name' => 'my-custom-name',
 
+            // This optional option determines the system name sent with the
+            // message in the 'source' field. When Forgotten or set to null,
+            // the current hostname is used.
+            'system_name' => null,
+
             // This optional option determines the host that will receive the
             // gelf log messages. Default is 127.0.0.1
             'host' => '127.0.0.1',

--- a/src/GelfLoggerFactory.php
+++ b/src/GelfLoggerFactory.php
@@ -63,7 +63,7 @@ class GelfLoggerFactory
 
         $handler = new GelfHandler(new Publisher($transport), $this->level($config));
 
-        $handler->setFormatter(new GelfMessageFormatter(null, null, null));
+        $handler->setFormatter(new GelfMessageFormatter($config['systemName'] ?? null, null, null));
 
         foreach ($this->parseProcessors($config) as $processor) {
             $handler->pushProcessor(new $processor);

--- a/src/GelfLoggerFactory.php
+++ b/src/GelfLoggerFactory.php
@@ -63,7 +63,7 @@ class GelfLoggerFactory
 
         $handler = new GelfHandler(new Publisher($transport), $this->level($config));
 
-        $handler->setFormatter(new GelfMessageFormatter($config['systemName'] ?? null, null, null));
+        $handler->setFormatter(new GelfMessageFormatter($config['system_name'] ?? null, null, null));
 
         foreach ($this->parseProcessors($config) as $processor) {
             $handler->pushProcessor(new $processor);

--- a/tests/GelfLoggerTest.php
+++ b/tests/GelfLoggerTest.php
@@ -58,4 +58,32 @@ class GelfLoggerTest extends Orchestra
 
         $handler->popProcessor();
     }
+
+    /** @test */
+    public function it_should_set_system_name_to_current_hostname_if_system_name_is_null(): void
+    {
+        $this->app['config']->set('logging.channels.gelf', [
+            'system_name' => null,
+            'driver' => 'custom',
+            'via' => GelfLoggerFactory::class
+        ]);
+
+        $logger = Log::channel('gelf');
+
+        $this->assertAttributeEquals(gethostname(), 'systemName', $logger->getHandlers()[0]->getFormatter());
+    }
+
+    /** @test */
+    public function it_should_set_system_name_to_custom_value_if_system_name_config_is_provided(): void
+    {
+        $this->app['config']->set('logging.channels.gelf', [
+            'system_name' => 'my-system-name',
+            'driver' => 'custom',
+            'via' => GelfLoggerFactory::class
+        ]);
+
+        $logger = Log::channel('gelf');
+
+        $this->assertAttributeEquals('my-system-name', 'systemName', $logger->getHandlers()[0]->getFormatter());
+    }
 }


### PR DESCRIPTION
Since docker containers often have the container ID as host name
and the same containers are deployed on several environments,
it should be possible to override it, so that messages can be
filtered by "source" in Graylog.