### PR TITLE
Added support for TCP transport

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@ A package to send [gelf](http://docs.graylog.org/en/2.1/pages/gelf.html) logs to
 
 It uses the new [Laravel custom log channel](https://laravel.com/docs/master/logging) introduced in Laravel 5.6.
 
-A gelf receiver like graylog2 must be configured to receive messages with a GELF UDP Input.
+A gelf receiver like graylog2 must be configured to receive messages with a GELF UDP or TCP Input.
 
 ## Table of contents
 
@@ -70,6 +70,10 @@ return [
             // the current hostname is used.
             'system_name' => null,
 
+            // This optional option determines if you want the TCP transport
+            // for the gelf log messages. Default is UDP
+            'transport' => 'udp'
+
             // This optional option determines the host that will receive the
             // gelf log messages. Default is 127.0.0.1
             'host' => '127.0.0.1',
@@ -77,10 +81,6 @@ return [
             // This optional option determines the port on which the gelf
             // receiver host is listening. Default is 12201
             'port' => 12201,
-
-            // This optional option determines if you want the TCP transport
-            // for the gelf log messages. Default is UDP
-            'transport' => 'udp'
         ],
     ],
 ];

--- a/readme.md
+++ b/readme.md
@@ -44,7 +44,7 @@ return [
             'driver' => 'custom',
 
             'via' => \Hedii\LaravelGelfLogger\GelfLoggerFactory::class,
-            
+
             // This optional option determines the processors that should be
             // pushed to the handler. This option is useful to modify a field
             // in the log context (see NullStringProcessor), or to add extra
@@ -77,6 +77,10 @@ return [
             // This optional option determines the port on which the gelf
             // receiver host is listening. Default is 12201
             'port' => 12201,
+
+            // This optional option determines if you want the TCP transport
+            // for the gelf log messages. Default is UDP
+            'transport' => 'udp'
         ],
     ],
 ];

--- a/src/GelfLoggerFactory.php
+++ b/src/GelfLoggerFactory.php
@@ -3,6 +3,7 @@
 namespace Hedii\LaravelGelfLogger;
 
 use Gelf\Publisher;
+use Gelf\Transport\AbstractTransport;
 use Gelf\Transport\IgnoreErrorTransportWrapper;
 use Gelf\Transport\UdpTransport;
 use Gelf\Transport\TcpTransport;
@@ -78,12 +79,12 @@ class GelfLoggerFactory
      * Get the transport class based on the
      * config value.
      *
-     * @param  string $transport
-     * @param  string $host
-     * @param  int $port
-     * @return \Gelf\Transport\AbstractTranport
+     * @param string $transport
+     * @param string $host
+     * @param int $port
+     * @return \Gelf\Transport\AbstractTransport
      */
-    protected function getTransport(string $transport, string $host, int $port)
+    protected function getTransport(string $transport, string $host, int $port): AbstractTransport
     {
         switch ($transport) {
             case 'tcp':

--- a/src/GelfLoggerFactory.php
+++ b/src/GelfLoggerFactory.php
@@ -3,14 +3,14 @@
 namespace Hedii\LaravelGelfLogger;
 
 use Gelf\Publisher;
-use Monolog\Logger;
-use InvalidArgumentException;
-use Gelf\Transport\TcpTransport;
-use Gelf\Transport\UdpTransport;
-use Monolog\Handler\GelfHandler;
-use Monolog\Formatter\GelfMessageFormatter;
-use Illuminate\Contracts\Container\Container;
 use Gelf\Transport\IgnoreErrorTransportWrapper;
+use Gelf\Transport\UdpTransport;
+use Gelf\Transport\TcpTransport;
+use Illuminate\Contracts\Container\Container;
+use InvalidArgumentException;
+use Monolog\Formatter\GelfMessageFormatter;
+use Monolog\Handler\GelfHandler;
+use Monolog\Logger;
 
 class GelfLoggerFactory
 {
@@ -55,15 +55,11 @@ class GelfLoggerFactory
      */
     public function __invoke(array $config): Logger
     {
-        $host = $config['host'] ?? '127.0.0.1';
-        $port = $config['port'] ?? 12201;
-        $transportType = $config['transport'] ?? 'udp';
-
         $transport = new IgnoreErrorTransportWrapper(
             $this->getTransport(
-                $transportType,
-                $host,
-                $port
+                $config['transport'] ?? 'udp',
+                $config['host'] ?? '127.0.0.1',
+                $config['port'] ?? 12201
             )
         );
 
@@ -85,7 +81,7 @@ class GelfLoggerFactory
      * @param  string $transport
      * @param  string $host
      * @param  int $port
-     * @return \Gelf\Transport\UdpTransport|\Gelf\Transport\TcpTransport
+     * @return \Gelf\Transport\AbstractTranport
      */
     protected function getTransport(string $transport, string $host, int $port)
     {
@@ -93,7 +89,7 @@ class GelfLoggerFactory
             case 'tcp':
                 return new TcpTransport($host, $port);
 
-            case 'udp':
+            default:
                 return new UdpTransport($host, $port);
         }
     }

--- a/tests/GelfLoggerTest.php
+++ b/tests/GelfLoggerTest.php
@@ -2,14 +2,14 @@
 
 namespace Hedii\LaravelGelfLogger\Tests;
 
-use Monolog\Logger;
-use Gelf\Transport\TcpTransport;
-use Gelf\Transport\UdpTransport;
-use Monolog\Handler\GelfHandler;
+use Hedii\LaravelGelfLogger\GelfLoggerFactory;
 use Illuminate\Support\Facades\Log;
 use Monolog\Formatter\GelfMessageFormatter;
-use Hedii\LaravelGelfLogger\GelfLoggerFactory;
+use Monolog\Handler\GelfHandler;
+use Monolog\Logger;
 use Orchestra\Testbench\TestCase as Orchestra;
+use Gelf\Transport\TcpTransport;
+use Gelf\Transport\UdpTransport;
 
 class GelfLoggerTest extends Orchestra
 {
@@ -99,8 +99,8 @@ class GelfLoggerTest extends Orchestra
         ]);
 
         $logger = Log::channel('gelf');
-        $publisher = $this->getObjectAttribute($logger->getHandlers()[0], 'publisher');
-        $transport = $this->getObjectAttribute($publisher->getTransports()[0], 'transport');
+        $publisher = $this->getAttribute($logger->getHandlers()[0], 'publisher');
+        $transport = $this->getAttribute($publisher->getTransports()[0], 'transport');
 
         $this->assertInstanceOf(TcpTransport::class, $transport);
     }
@@ -114,9 +114,30 @@ class GelfLoggerTest extends Orchestra
         ]);
 
         $logger = Log::channel('gelf');
-        $publisher = $this->getObjectAttribute($logger->getHandlers()[0], 'publisher');
-        $transport = $this->getObjectAttribute($publisher->getTransports()[0], 'transport');
+        $publisher = $this->getAttribute($logger->getHandlers()[0], 'publisher');
+        $transport = $this->getAttribute($publisher->getTransports()[0], 'transport');
 
         $this->assertInstanceOf(UdpTransport::class, $transport);
+    }
+
+    /**
+     * Get protected or private attribute from an object.
+     * NOTICE: This method is for testing purposes only.
+     *
+     * @param object $object
+     * @param string $property
+     * @return mixed
+     * @throws Exception
+     */
+    protected function getAttribute($object, $property) {
+        try {
+            $reflector = new \ReflectionClass($object);
+            $attribute = $reflector->getProperty($property);
+            $attribute->setAccessible(true);
+
+            return $attribute->getValue($object);
+        } catch (Exception $e) {
+            throw new Exception("Can't get attribute from the provided object");
+        }
     }
 }


### PR DESCRIPTION
Sometimes we want to be sure that everything we log is going to be sent,
and because UDP is unreliable and we might lost some data, we must
use TCP transport.