### PR TITLE
Refactor: do not use dataProver for Gelf message test

### DIFF
--- a/tests/GelfMessageTest.php
+++ b/tests/GelfMessageTest.php
@@ -8,89 +8,18 @@ use Orchestra\Testbench\TestCase as Orchestra;
 
 class GelfMessageTest extends Orchestra
 {
-    public function messagePrefixProvider(): array
-    {
-        return [
-            'Add context and extra prefix' => [
-                'parameters' => [
-                    'context_prefix' => 'ctxt_',
-                    'context_variable' => 'id',
-                    'extra_prefix' => 'extra_',
-                    'extra_variable' => 'ip'
-                ],
-                'expected_response' => [
-                    'context_response' => 'ctxt_id',
-                    'extra_response' => 'extra_ip'
-                ]
-            ],
-            'Empty context and extra config values' => [
-                'parameters' => [
-                    'context_variable' => 'id',
-                    'extra_variable' => 'ip'
-                ],
-                'expected_response' => [
-                    'context_response' => 'id',
-                    'extra_response' => 'ip'
-                ]
-            ],
-            'Empty extra config value' => [
-                'parameters' => [
-                    'context_prefix' => 'ctxt_',
-                    'context_variable' => 'id',
-                    'extra_variable' => 'ip'
-                ],
-                'expected_response' => [
-                    'context_response' => 'ctxt_id',
-                    'extra_response' => 'ip'
-                ]
-            ],
-            'Empty context config value' => [
-                'parameters' => [
-                    'context_variable' => 'id',
-                    'extra_variable' => 'ip',
-                    'extra_prefix' => 'extra_'
-                ],
-                'expected_response' => [
-                    'context_response' => 'id',
-                    'extra_response' => 'extra_ip'
-                ]
-            ],
-            'Null context and extra config values' => [
-                'parameters' => [
-                    'context_prefix' => null,
-                    'context_variable' => 'id',
-                    'extra_prefix' => null,
-                    'extra_variable' => 'ip'
-                ],
-                'expected_response' => [
-                    'context_response' => 'id',
-                    'extra_response' => 'ip'
-                ]
-            ],
-        ];
-    }
-
     /**
      * @test
-     * @dataProvider messagePrefixProvider
-     * @param array $parameters
-     * @param array $expectedResponse
      */
-    public function it_should_append_prefixes_to_gelf_message_variables(array $parameters, array $expectedResponse): void
+    public function it_should_append_prefixes(): void
     {
         $loggerConfig = [
             'system_name' => 'my-system-namex',
             'driver' => 'custom',
             'via' => GelfLoggerFactory::class,
+            'context_prefix' => 'ctxt_',
+            'extra_prefix' => 'extra_'
         ];
-
-        if (isset($parameters['context_prefix'])) {
-            $loggerConfig['context_prefix'] = $parameters['context_prefix'];
-        }
-
-        if (isset($parameters['extra_prefix'])) {
-            $loggerConfig['extra_prefix'] = $parameters['extra_prefix'];
-        }
 
         $this->app['config']->set('logging.channels.gelf', $loggerConfig);
 
@@ -100,11 +29,69 @@ class GelfMessageTest extends Orchestra
             'datetime' => '1591097093.0',
             'message' => 'test',
             'level' => 100,
-            'extra' => [$parameters['extra_variable'] => '127.0.0.1'],
-            'context' => [$parameters['context_variable'] => '777']
+            'extra' => ['ip' => '127.0.0.1', 'source' => 'tests'],
+            'context' => ['id' => '777', 'message' => 'custom']
         ]);
 
-        $this->assertArrayHasKey($expectedResponse['extra_response'], $formattedMessage->getAllAdditionals());
-        $this->assertArrayHasKey($expectedResponse['context_response'], $formattedMessage->getAllAdditionals());
+        $this->assertArrayHasKey('extra_ip', $formattedMessage->getAllAdditionals());
+        $this->assertArrayHasKey('extra_source', $formattedMessage->getAllAdditionals());
+        $this->assertArrayHasKey('ctxt_id', $formattedMessage->getAllAdditionals());
+        $this->assertArrayHasKey('ctxt_message', $formattedMessage->getAllAdditionals());
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_not_append_prefixes(): void
+    {
+        $loggerConfig = [
+            'system_name' => 'my-system-namex',
+            'driver' => 'custom',
+            'via' => GelfLoggerFactory::class
+        ];
+
+        $this->app['config']->set('logging.channels.gelf', $loggerConfig);
+
+        $logger = Log::channel('gelf');
+
+        $formattedMessage = $logger->getHandlers()[0]->getFormatter()->format([
+            'datetime' => '1591097093.0',
+            'message' => 'test',
+            'level' => 100,
+            'extra' => ['ip' => '127.0.0.1'],
+            'context' => ['id' => '777']
+        ]);
+
+        $this->assertArrayHasKey('ip', $formattedMessage->getAllAdditionals());
+        $this->assertArrayHasKey('id', $formattedMessage->getAllAdditionals());
+    }
+
+    /**
+     * @test
+     */
+    public function null_config_variables_should_not_add_prefixes(): void
+    {
+        $loggerConfig = [
+            'system_name' => 'my-system-namex',
+            'driver' => 'custom',
+            'via' => GelfLoggerFactory::class,
+            'context_prefix' => null,
+            'extra_prefix' => null
+        ];
+
+        $this->app['config']->set('logging.channels.gelf', $loggerConfig);
+
+        $logger = Log::channel('gelf');
+
+        $formattedMessage = $logger->getHandlers()[0]->getFormatter()->format([
+            'datetime' => '1591097093.0',
+            'message' => 'test',
+            'level' => 100,
+            'extra' => ['ip' => '127.0.0.1'],
+            'context' => ['id' => '777']
+        ]);
+
+        $this->assertArrayHasKey('ip', $formattedMessage->getAllAdditionals());
+        $this->assertArrayHasKey('id', $formattedMessage->getAllAdditionals());
     }
 }

--- a/tests/GelfMessageTest.php
+++ b/tests/GelfMessageTest.php
@@ -8,24 +8,18 @@ use Orchestra\Testbench\TestCase as Orchestra;
 
 class GelfMessageTest extends Orchestra
 {
-    /**
-     * @test
-     */
+    /** @test */
     public function it_should_append_prefixes(): void
     {
-        $loggerConfig = [
+        $this->app['config']->set('logging.channels.gelf', [
             'system_name' => 'my-system-namex',
             'driver' => 'custom',
             'via' => GelfLoggerFactory::class,
             'context_prefix' => 'ctxt_',
             'extra_prefix' => 'extra_'
-        ];
+        ]);
 
-        $this->app['config']->set('logging.channels.gelf', $loggerConfig);
-
-        $logger = Log::channel('gelf');
-
-        $formattedMessage = $logger->getHandlers()[0]->getFormatter()->format([
+        $formattedMessage = Log::channel('gelf')->getHandlers()[0]->getFormatter()->format([
             'datetime' => '1591097093.0',
             'message' => 'test',
             'level' => 100,
@@ -39,22 +33,16 @@ class GelfMessageTest extends Orchestra
         $this->assertArrayHasKey('ctxt_message', $formattedMessage->getAllAdditionals());
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function it_should_not_append_prefixes(): void
     {
-        $loggerConfig = [
+        $this->app['config']->set('logging.channels.gelf', [
             'system_name' => 'my-system-namex',
             'driver' => 'custom',
             'via' => GelfLoggerFactory::class
-        ];
+        ]);
 
-        $this->app['config']->set('logging.channels.gelf', $loggerConfig);
-
-        $logger = Log::channel('gelf');
-
-        $formattedMessage = $logger->getHandlers()[0]->getFormatter()->format([
+        $formattedMessage = Log::channel('gelf')->getHandlers()[0]->getFormatter()->format([
             'datetime' => '1591097093.0',
             'message' => 'test',
             'level' => 100,
@@ -66,24 +54,18 @@ class GelfMessageTest extends Orchestra
         $this->assertArrayHasKey('id', $formattedMessage->getAllAdditionals());
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function null_config_variables_should_not_add_prefixes(): void
     {
-        $loggerConfig = [
+        $this->app['config']->set('logging.channels.gelf', [
             'system_name' => 'my-system-namex',
             'driver' => 'custom',
             'via' => GelfLoggerFactory::class,
             'context_prefix' => null,
             'extra_prefix' => null
-        ];
+        ]);
 
-        $this->app['config']->set('logging.channels.gelf', $loggerConfig);
-
-        $logger = Log::channel('gelf');
-
-        $formattedMessage = $logger->getHandlers()[0]->getFormatter()->format([
+        $formattedMessage = Log::channel('gelf')->getHandlers()[0]->getFormatter()->format([
             'datetime' => '1591097093.0',
             'message' => 'test',
             'level' => 100,


### PR DESCRIPTION
related https://github.com/hedii/laravel-gelf-logger/pull/18

