### PR TITLE
Feature/specify custom ssl settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,30 @@ return [
             // transport. When forgotten or set to null, default path '/gelf'
             // is used.
             'path' => null,
+            
+            // This optional option enable or disable ssl on TCP transport.
+            // Default is false.
+            'ssl' => false,
+            
+            // If ssl is enabled on TCP transport, the following configuration
+            // is used.
+            'ssl_options' => [
+                // Enable or disable the peer certificate check. Default is
+                // null.
+                'verify_peer' => true,
+                
+                // Path to a custom CA file (eg: "/path/to/ca.pem"). Default
+                // is null.
+                'ca_file' => null,
+                
+                // List of ciphers the SSL layer may use, formatted as
+                // specified in ciphers(1). Default is null.
+                'ciphers' => null,
+                
+                // Whether self-signed certificates are allowed. Default is
+                // false.
+                'allow_self_signed' => false,
+            ],
 
             // This optional option determines the maximum length per message
             // field. When forgotten or set to null, the default value of 
@@ -114,16 +138,6 @@ return [
             // from the Monolog record. Default is null (no extra prefix)
             'extra_prefix' => null,
 
-            // Optional option to set ssl on tcp requests. On udp requests this is ignored
-            // This configuration will be added the specified port in this configuration item.
-            // The base package of graylog is only setting ssl on port 12202.
-            // When you just want base settings of graylog2/gelf-php then you don't specify this attribute.
-            'ssl' => [
-                'verify_peer' => true,
-                'ca_file' => '/path/to/ca.pem',  // or null
-                'ciphers' => 'TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256', // or null
-                'allow_self_signed' => false,
-            ]
         ],
     ],
 ];

--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ return [
 
         'gelf' => [
             'driver' => 'custom',
-            
 
             'via' => \Hedii\LaravelGelfLogger\GelfLoggerFactory::class,
 
@@ -114,6 +113,17 @@ return [
             // This optional option determines the prefix for 'extra' fields
             // from the Monolog record. Default is null (no extra prefix)
             'extra_prefix' => null,
+
+            // Optional option to set ssl on tcp requests. On udp requests this is ignored
+            // This configuration will be added the specified port in this configuration item.
+            // The base package of graylog is only setting ssl on port 12202.
+            // When you just want base settings of graylog2/gelf-php then you don't specify this attribute.
+            'ssl' => [
+                'verify_peer' => true,
+                'ca_file' => '/path/to/ca.pem',  // or null
+                'ciphers' => 'TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256', // or null
+                'allow_self_signed' => false,
+            ]
         ],
     ],
 ];

--- a/src/GelfLoggerFactory.php
+++ b/src/GelfLoggerFactory.php
@@ -128,10 +128,10 @@ class GelfLoggerFactory
 		}
 
 		$sslOptions = new SslOptions();
-		$sslOptions->setAllowSelfSigned((bool) $ssl['allow_self_signed'] ?? false);
+		$sslOptions->setAllowSelfSigned($ssl['allow_self_signed'] ?? false);
 		$sslOptions->setCaFile($ssl['ca_file'] ?? null);
 		$sslOptions->setCiphers($ssl['ciphers'] ?? null);
-		$sslOptions->setVerifyPeer((bool) $ssl['verify_peer'] ?? true);
+		$sslOptions->setVerifyPeer($ssl['verify_peer'] ?? true);
 
 		return $sslOptions;
 	}

--- a/tests/GelfLoggerTest.php
+++ b/tests/GelfLoggerTest.php
@@ -32,7 +32,7 @@ class GelfLoggerTest extends Orchestra
             'level' => 'notice',
             'name' => 'my-custom-name',
             'host' => '127.0.0.2',
-            'port' => 12202
+            'port' => 12202,
         ]);
     }
 
@@ -76,7 +76,7 @@ class GelfLoggerTest extends Orchestra
         $this->app['config']->set('logging.channels.gelf', [
             'system_name' => null,
             'driver' => 'custom',
-            'via' => GelfLoggerFactory::class
+            'via' => GelfLoggerFactory::class,
         ]);
 
         $logger = Log::channel('gelf');
@@ -93,7 +93,7 @@ class GelfLoggerTest extends Orchestra
         $this->app['config']->set('logging.channels.gelf', [
             'system_name' => 'my-system-name',
             'driver' => 'custom',
-            'via' => GelfLoggerFactory::class
+            'via' => GelfLoggerFactory::class,
         ]);
 
         $logger = Log::channel('gelf');
@@ -110,7 +110,7 @@ class GelfLoggerTest extends Orchestra
         $this->app['config']->set('logging.channels.gelf', [
             'transport' => 'tcp',
             'driver' => 'custom',
-            'via' => GelfLoggerFactory::class
+            'via' => GelfLoggerFactory::class,
         ]);
 
         $logger = Log::channel('gelf');
@@ -125,7 +125,7 @@ class GelfLoggerTest extends Orchestra
     {
         $this->app['config']->set('logging.channels.gelf', [
             'driver' => 'custom',
-            'via' => GelfLoggerFactory::class
+            'via' => GelfLoggerFactory::class,
         ]);
 
         $logger = Log::channel('gelf');
@@ -141,7 +141,7 @@ class GelfLoggerTest extends Orchestra
         $this->app['config']->set('logging.channels.gelf', [
             'driver' => 'custom',
             'via' => GelfLoggerFactory::class,
-            'max_length' => 9999
+            'max_length' => 9999,
         ]);
 
         $logger = Log::channel('gelf');
@@ -157,7 +157,7 @@ class GelfLoggerTest extends Orchestra
     {
         $this->app['config']->set('logging.channels.gelf', [
             'driver' => 'custom',
-            'via' => GelfLoggerFactory::class
+            'via' => GelfLoggerFactory::class,
         ]);
 
         $logger = Log::channel('gelf');
@@ -174,7 +174,7 @@ class GelfLoggerTest extends Orchestra
         $this->app['config']->set('logging.channels.gelf', [
             'driver' => 'custom',
             'via' => GelfLoggerFactory::class,
-            'max_length' => null
+            'max_length' => null,
         ]);
 
         $logger = Log::channel('gelf');
@@ -191,7 +191,7 @@ class GelfLoggerTest extends Orchestra
         $this->app['config']->set('logging.channels.gelf', [
             'driver' => 'custom',
             'via' => GelfLoggerFactory::class,
-            'transport' => 'http'
+            'transport' => 'http',
         ]);
 
         $logger = Log::channel('gelf');
@@ -208,7 +208,7 @@ class GelfLoggerTest extends Orchestra
             'driver' => 'custom',
             'via' => GelfLoggerFactory::class,
             'transport' => 'http',
-            'path' => '/custom-path'
+            'path' => '/custom-path',
         ]);
 
         $logger = Log::channel('gelf');
@@ -226,7 +226,7 @@ class GelfLoggerTest extends Orchestra
             'driver' => 'custom',
             'via' => GelfLoggerFactory::class,
             'transport' => 'http',
-            'path' => null
+            'path' => null,
         ]);
 
         $logger = Log::channel('gelf');
@@ -243,7 +243,7 @@ class GelfLoggerTest extends Orchestra
         $this->app['config']->set('logging.channels.gelf', [
             'driver' => 'custom',
             'via' => GelfLoggerFactory::class,
-            'transport' => 'http'
+            'transport' => 'http',
         ]);
 
         $logger = Log::channel('gelf');
@@ -254,74 +254,192 @@ class GelfLoggerTest extends Orchestra
         $this->assertSame(HttpTransport::DEFAULT_PATH, $this->getAttribute($transport, 'path'));
     }
 
-	/** @test */
-	public function it_should_set_the_ssl_options_and_overrule_base_package_for_tcp_connections()
-	{
-		$this->app['config']->set('logging.channels.gelf', [
-			'driver' => 'custom',
-			'via' => GelfLoggerFactory::class,
-			'transport' => 'tcp',
-			'port' => 12202,
-			'ssl' => [
-				'verify_peer' => false,
-				'ca_file' => '/path/to/ca.pem',
-				'ciphers' => 'TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256',
-				'allow_self_signed' => true,
-			],
-		]);
+    /** @test */
+    public function it_should_set_the_ssl_options_for_tcp_transport()
+    {
+        $this->app['config']->set('logging.channels.gelf', [
+            'driver' => 'custom',
+            'via' => GelfLoggerFactory::class,
+            'transport' => 'tcp',
+            'port' => 12202,
+            'ssl' => true,
+            'ssl_options' => [
+                'verify_peer' => false,
+                'ca_file' => '/path/to/ca.pem',
+                'ciphers' => 'TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256',
+                'allow_self_signed' => true,
+            ],
+        ]);
 
-		$logger = Log::channel('gelf');
-		$publisher = $this->getAttribute($logger->getHandlers()[0], 'publisher');
-		$transport = $this->getAttribute($publisher->getTransports()[0], 'transport');
+        $logger = Log::channel('gelf');
+        $publisher = $this->getAttribute($logger->getHandlers()[0], 'publisher');
+        $transport = $this->getAttribute($publisher->getTransports()[0], 'transport');
 
-		/** @var SslOptions $sslOptions */
-		$sslOptions = $this->getAttribute($transport, 'sslOptions');
+        /** @var SslOptions $sslOptions */
+        $sslOptions = $this->getAttribute($transport, 'sslOptions');
 
-		$this->assertFalse($sslOptions->getVerifyPeer());
-		$this->assertTrue($sslOptions->getAllowSelfSigned());
-		$this->assertEquals('/path/to/ca.pem', $sslOptions->getCaFile());
-		$this->assertEquals('TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256', $sslOptions->getCiphers());
-	}
+        $this->assertFalse($sslOptions->getVerifyPeer());
+        $this->assertTrue($sslOptions->getAllowSelfSigned());
+        $this->assertEquals('/path/to/ca.pem', $sslOptions->getCaFile());
+        $this->assertEquals('TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256', $sslOptions->getCiphers());
+    }
+
+    /** @test */
+    public function it_should_set_the_ssl_options_for_http_transport()
+    {
+        $this->app['config']->set('logging.channels.gelf', [
+            'driver' => 'custom',
+            'via' => GelfLoggerFactory::class,
+            'transport' => 'http',
+            'port' => 443,
+            'ssl' => true,
+            'ssl_options' => [
+                'verify_peer' => false,
+                'ca_file' => '/path/to/ca.pem',
+                'ciphers' => 'TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256',
+                'allow_self_signed' => true,
+            ],
+        ]);
+
+        $logger = Log::channel('gelf');
+        $publisher = $this->getAttribute($logger->getHandlers()[0], 'publisher');
+        $transport = $this->getAttribute($publisher->getTransports()[0], 'transport');
+
+        /** @var SslOptions $sslOptions */
+        $sslOptions = $this->getAttribute($transport, 'sslOptions');
+
+        $this->assertFalse($sslOptions->getVerifyPeer());
+        $this->assertTrue($sslOptions->getAllowSelfSigned());
+        $this->assertEquals('/path/to/ca.pem', $sslOptions->getCaFile());
+        $this->assertEquals('TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256', $sslOptions->getCiphers());
+    }
 
 
-	/** @test */
-	public function it_should_not_add_ssl_on_tcp_when_the_ssl_config_is_missing()
-	{
-		$this->app['config']->set('logging.channels.gelf', [
-			'driver' => 'custom',
-			'via' => GelfLoggerFactory::class,
-			'transport' => 'tcp',
-		]);
+    /** @test */
+    public function it_should_not_add_ssl_on_tcp_transport_when_the_ssl_config_is_missing_or_set_to_false()
+    {
+        $this->app['config']->set('logging.channels.gelf', [
+            'driver' => 'custom',
+            'via' => GelfLoggerFactory::class,
+            'transport' => 'tcp',
+            'ssl_options' => [
+                'verify_peer' => false,
+                'ca_file' => '/path/to/ca.pem',
+                'ciphers' => 'TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256',
+                'allow_self_signed' => true,
+            ],
+        ]);
 
-		$logger = Log::channel('gelf');
-		$publisher = $this->getAttribute($logger->getHandlers()[0], 'publisher');
-		$transport = $this->getAttribute($publisher->getTransports()[0], 'transport');
+        $logger = Log::channel('gelf');
+        $publisher = $this->getAttribute($logger->getHandlers()[0], 'publisher');
+        $transport = $this->getAttribute($publisher->getTransports()[0], 'transport');
 
-		$this->assertNull($this->getAttribute($transport, 'sslOptions'));
-	}
+        $this->assertNull($this->getAttribute($transport, 'sslOptions'));
 
-	/** @test */
-	public function it_should_uses_the_default_ssl_options_on_ssl_port_without_specifying_ours()
-	{
-		$this->app['config']->set('logging.channels.gelf', [
-			'driver' => 'custom',
-			'via' => GelfLoggerFactory::class,
-			'transport' => 'tcp',
-			'port' => 12202,
-		]);
+        $this->app['config']->set('logging.channels.gelf', [
+            'driver' => 'custom',
+            'via' => GelfLoggerFactory::class,
+            'transport' => 'tcp',
+            'ssl' => false,
+            'ssl_options' => [
+                'verify_peer' => false,
+                'ca_file' => '/path/to/ca.pem',
+                'ciphers' => 'TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256',
+                'allow_self_signed' => true,
+            ],
+        ]);
 
-		$logger = Log::channel('gelf');
-		$publisher = $this->getAttribute($logger->getHandlers()[0], 'publisher');
-		$transport = $this->getAttribute($publisher->getTransports()[0], 'transport');
+        $logger = Log::channel('gelf');
+        $publisher = $this->getAttribute($logger->getHandlers()[0], 'publisher');
+        $transport = $this->getAttribute($publisher->getTransports()[0], 'transport');
 
-		/** @var SslOptions $sslOptions */
-		$sslOptions = $this->getAttribute($transport, 'sslOptions');
+        $this->assertNull($this->getAttribute($transport, 'sslOptions'));
+    }
 
-		$this->assertTrue($sslOptions->getVerifyPeer());
-		$this->assertFalse($sslOptions->getAllowSelfSigned());
-		$this->assertNull($sslOptions->getCaFile());
-		$this->assertNull($sslOptions->getCiphers());
-	}
+    /** @test */
+    public function it_should_not_add_ssl_on_http_transport_when_the_ssl_config_is_missing_or_set_to_false()
+    {
+        $this->app['config']->set('logging.channels.gelf', [
+            'driver' => 'custom',
+            'via' => GelfLoggerFactory::class,
+            'transport' => 'http',
+            'ssl_options' => [
+                'verify_peer' => false,
+                'ca_file' => '/path/to/ca.pem',
+                'ciphers' => 'TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256',
+                'allow_self_signed' => true,
+            ],
+        ]);
+
+        $logger = Log::channel('gelf');
+        $publisher = $this->getAttribute($logger->getHandlers()[0], 'publisher');
+        $transport = $this->getAttribute($publisher->getTransports()[0], 'transport');
+
+        $this->assertNull($this->getAttribute($transport, 'sslOptions'));
+
+        $this->app['config']->set('logging.channels.gelf', [
+            'driver' => 'custom',
+            'via' => GelfLoggerFactory::class,
+            'transport' => 'http',
+            'ssl' => false,
+            'ssl_options' => [
+                'verify_peer' => false,
+                'ca_file' => '/path/to/ca.pem',
+                'ciphers' => 'TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256',
+                'allow_self_signed' => true,
+            ],
+        ]);
+
+        $logger = Log::channel('gelf');
+        $publisher = $this->getAttribute($logger->getHandlers()[0], 'publisher');
+        $transport = $this->getAttribute($publisher->getTransports()[0], 'transport');
+
+        $this->assertNull($this->getAttribute($transport, 'sslOptions'));
+    }
+
+    /** @test */
+    public function it_should_use_the_default_ssl_options_when_ssl_options_is_missing()
+    {
+        $this->app['config']->set('logging.channels.gelf', [
+            'driver' => 'custom',
+            'via' => GelfLoggerFactory::class,
+            'transport' => 'tcp',
+            'port' => 12202,
+            'ssl' => true,
+        ]);
+
+        $logger = Log::channel('gelf');
+        $publisher = $this->getAttribute($logger->getHandlers()[0], 'publisher');
+        $transport = $this->getAttribute($publisher->getTransports()[0], 'transport');
+
+        /** @var SslOptions $sslOptions */
+        $sslOptions = $this->getAttribute($transport, 'sslOptions');
+
+        $this->assertTrue($sslOptions->getVerifyPeer());
+        $this->assertFalse($sslOptions->getAllowSelfSigned());
+        $this->assertNull($sslOptions->getCaFile());
+        $this->assertNull($sslOptions->getCiphers());
+
+        $this->app['config']->set('logging.channels.gelf', [
+            'driver' => 'custom',
+            'via' => GelfLoggerFactory::class,
+            'transport' => 'http',
+            'port' => 443,
+            'ssl' => true,
+        ]);
+
+        $logger = Log::channel('gelf');
+        $publisher = $this->getAttribute($logger->getHandlers()[0], 'publisher');
+        $transport = $this->getAttribute($publisher->getTransports()[0], 'transport');
+
+        /** @var SslOptions $sslOptions */
+        $sslOptions = $this->getAttribute($transport, 'sslOptions');
+
+        $this->assertTrue($sslOptions->getVerifyPeer());
+        $this->assertFalse($sslOptions->getAllowSelfSigned());
+        $this->assertNull($sslOptions->getCaFile());
+        $this->assertNull($sslOptions->getCiphers());
+    }
 
     /**
      * Get protected or private attribute from an object.


### PR DESCRIPTION
Now you can configure the ssl options in a TCP request and uses our own settings in the configuration of `gelf`. I have added some tests to make the results clear and updated the the config example in `readme.MD` to make it clear. 