### PR TITLE
Laravel 9 compatibility

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: [ '7.3', '7.4', '8.0', '8.1' ]
+        php-versions: [ '8.0', '8.1' ]
     name: Testing on PHP ${{ matrix.php-versions }}
     steps:
       - name: Checkout

--- a/composer.json
+++ b/composer.json
@@ -26,12 +26,12 @@
         "source": "https://github.com/hedii/laravel-gelf-logger"
     },
     "require": {
-        "php": "^7.3|^8.0",
-        "illuminate/log": "^8.12",
-        "graylog2/gelf-php": "^1.6"
+        "php": "^8.0",
+        "illuminate/log": "^8.0|^9.0",
+        "graylog2/gelf-php": "^1.7"
     },
     "require-dev": {
-        "orchestra/testbench": "^6.0"
+        "orchestra/testbench": "^7.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     },
     "require": {
         "php": "^8.0",
-        "illuminate/log": "^8.0|^9.0",
+        "illuminate/log": "^9.0",
         "graylog2/gelf-php": "^1.7"
     },
     "require-dev": {

--- a/src/GelfLoggerFactory.php
+++ b/src/GelfLoggerFactory.php
@@ -72,7 +72,7 @@ class GelfLoggerFactory
         ?string $path = null,
         ?SslOptions $sslOptions = null
     ): AbstractTransport {
-        return match (strtolower($transport)) {
+        return match(strtolower($transport)) {
             'tcp' => new TcpTransport($host, $port, $sslOptions),
             'http' => new HttpTransport($host, $port, $path ?? HttpTransport::DEFAULT_PATH, $sslOptions),
             default => new UdpTransport($host, $port),

--- a/src/GelfLoggerFactory.php
+++ b/src/GelfLoggerFactory.php
@@ -72,14 +72,11 @@ class GelfLoggerFactory
         ?string $path = null,
         ?SslOptions $sslOptions = null
     ): AbstractTransport {
-        switch (strtolower($transport)) {
-            case 'tcp':
-                return new TcpTransport($host, $port, $sslOptions);
-            case 'http':
-                return new HttpTransport($host, $port, $path ?? HttpTransport::DEFAULT_PATH, $sslOptions);
-            default:
-                return new UdpTransport($host, $port);
-        }
+        return match (strtolower($transport)) {
+            'tcp' => new TcpTransport($host, $port, $sslOptions),
+            'http' => new HttpTransport($host, $port, $path ?? HttpTransport::DEFAULT_PATH, $sslOptions),
+            default => new UdpTransport($host, $port),
+        };
     }
 
     protected function enableSsl(array $config): bool


### PR DESCRIPTION
- allow Laravel 9 (copied from https://github.com/hedii/laravel-gelf-logger/pull/35)
- remove old php versions from ci
- use match instead of switch