### PR TITLE
Added support for Laravel 13

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: [ '8.2', '8.3', '8.4' ]
+        php-versions: [ '8.3', '8.4' ]
     name: Testing on PHP ${{ matrix.php-versions }}
     steps:
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 | 10.0        | ^8.0                    |
 | 11.0        | ^9.0                    |
 | 12.0        | ^10.0                   |
+| 13.0        | ^13.0                   |
 
 A package to send [gelf](http://docs.graylog.org/en/2.1/pages/gelf.html) logs to a gelf compatible backend like graylog. It is a Laravel wrapper for [bzikarsky/gelf-php](https://github.com/bzikarsky/gelf-php) package.
 

--- a/composer.json
+++ b/composer.json
@@ -26,12 +26,12 @@
         "source": "https://github.com/hedii/laravel-gelf-logger"
     },
     "require": {
-        "php": "^8.2",
+        "php": "^8.3",
         "graylog2/gelf-php": "^2.0",
-        "illuminate/log": "^12.0"
+        "illuminate/log": "^13.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^10.0"
+        "orchestra/testbench": "^11.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Summary                                                                                                                                                                                                                           
                                                                                                                                                                                                                                    
  - Updated illuminate/log requirement from ^12.0 to ^13.0                                                                                                                                                                          
  - Updated orchestra/testbench dev dependency from ^10.0 to ^11.0
  - Bumped minimum PHP version from ^8.2 to ^8.3 (required by Laravel 13)         

Versioning recommendation                                                                                                                                                                                                         
                                                                                                                                                                                                                                    
  I recommend tagging this release as v13.0.0 to align the package version with the supported Laravel version, following the same convention as Laravel itself. This makes it immediately clear which package version supports which Laravel version.
                                                                                                                                                  
                                                                                                                                                                                                                                    